### PR TITLE
Tidy some docstrings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ genetic ancestry with structural variation).
 
 The library is a work-in-progress, and is not yet officially released.
 
+Please visit https://github.com/hyanwong/giglib to contribute to development.
+
 The rest of this documentation is organised into the following sections:
 
 ```{tableofcontents}

--- a/giglib/graph.py
+++ b/giglib/graph.py
@@ -312,8 +312,11 @@ class Graph:
         each iedge has the same child_left as parent_left and the same
         child_right as parent_right.
 
-        If sequence_length is not None, it will be used as the sequence length,
-        otherwise the sequence length will be the maximum position of any edge.
+        :param int sequence_length: The sequence length in the resulting
+            tree sequence (if ``None``, take the maximum position of any edge).
+        :return: A tree sequence
+        :rtype: tskit.TreeSequence
+
         """
         for ie in self.iedges:
             if ie.child_left != ie.parent_left or ie.child_right != ie.parent_right:
@@ -356,6 +359,10 @@ class Graph:
     def decapitate(self, time):
         """
         Return a new GIG with all nodes older than time removed.
+
+        :param float time: The cutoff time
+        :return: A new GIG object
+        :rtype: Graph
         """
         tables = self.tables.copy()  # placeholder for making these editable
         tables.decapitate(time)
@@ -369,6 +376,9 @@ class Graph:
         counting up the number of samples under each node. This is
         identical to the :meth:`Tables.sample_resolve` method, but returns
         a new GIG instead.
+
+        :return: A new GIG object
+        :rtype: Graph
         """
         new_tables = self.tables.copy()
         new_tables.sample_resolve()

--- a/giglib/tables.py
+++ b/giglib/tables.py
@@ -1136,8 +1136,11 @@ class Tables:
 
     def copy(self, omit_iedges=None):
         """
-        Return an unfrozen deep copy of the tables. If omit_iedges is True
-        do not copy the iedges table but use a blank one
+        Return an unfrozen deep copy of the tables.
+
+        :param bool omit_iedges: If True do not copy the iedges table, use an empty one.
+        :return: A deep copy of the tables
+        :rtype: giglib.Tables
         """
         copy = self.__class__()
         for name, cls in zip(self.table_classes._fields, self.table_classes):
@@ -1238,6 +1241,9 @@ class Tables:
         .. note::
             The nodes are not required to be in any particular order (e.g. by time)
 
+        :return: A genetic inheritance graph object
+        :rtype: giglib.Graph
+
         """
         from .graph import Graph
 
@@ -1247,6 +1253,8 @@ class Tables:
     def sample_ids(self):
         """
         Return the IDs of all samples in the nodes table
+
+        :rtype: numpy.ndarray
         """
         if len(self.nodes) == 0:
             return np.array([], dtype=np.int32)
@@ -1262,8 +1270,12 @@ class Tables:
     def decapitate(self, time):
         """
         Remove nodes that are older than a certain time, and edges that have those
-        as parents. Also remove individuals associated with those nodes. Return a
-        mapping of old node ids to new node ids.
+        as parents. Also remove individuals associated with those nodes.
+
+        :param float time: The time before which nodes should be removed
+        :return: An array mapping old node ids to new node ids (or -1 if removed)
+        :rtype: numpy.ndarray
+
         """
         individuals = IndividualTable()
         individual_map = {NULL: NULL}
@@ -1296,7 +1308,7 @@ class Tables:
         return node_map
 
     @classmethod
-    def from_tree_sequence(cls, ts, *, chromosome=None, timedelta=0, **kwargs):
+    def from_tree_sequence(cls, ts, *, chromosome=None, **kwargs):
         """
         Create a Tables object from a :class:`tskit:tskit.TreeSequence`. To create a GIG
         directly, use :func:`Graph.from_tree_sequence` which simply wraps this method.
@@ -1304,8 +1316,6 @@ class Tables:
         :param tskit.TreeSequence ts: The tree sequence on which to base the Tables
             object
         :param int chromosome: The chromosome number to use for all interval edges
-        :param float timedelta: A value to add to all node times (this is a hack until
-            we can set entire columns like in tskit, see #issues/19)
         :param kwargs: Other parameters passed to the Tables constructor
         :return: A Tables object representing the tree sequence
         :rtype: Tables
@@ -1330,7 +1340,6 @@ class Tables:
             raise NotImplementedError
         for row in ts_tables.nodes:
             obj = dataclasses.asdict(row)
-            obj["time"] += timedelta
             tables.nodes.append(obj)
         for row in ts_tables.edges:
             obj = dataclasses.asdict(row)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -31,7 +31,8 @@ class TestCreation:
     @pytest.mark.parametrize("time", [0, 1])
     def test_simple_from_tree_sequence_with_timedelta(self, simple_ts, time):
         assert simple_ts.num_trees > 1
-        tables = gigl.Tables.from_tree_sequence(simple_ts, timedelta=time)
+        tables = gigl.Tables.from_tree_sequence(simple_ts)
+        tables.change_times(timedelta=time)
         assert tables.nodes[0].time == simple_ts.node(0).time + time
 
     def test_mutations_not_implemented_error(self, simple_ts_with_mutations):


### PR DESCRIPTION
And remove extraneous timedelta param

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a call to action for contributions by providing a link to the GitHub repository.
	- Enhanced method documentation in the `Graph` class for better clarity.

- **Refactor**
	- Updated methods in `Graph` and `Tables` classes to include parameter and return type annotations.
	- Removed the `timedelta` parameter from the `from_tree_sequence` method and adjusted related logic.

- **Tests**
	- Modified the test case to handle time changes differently, improving test coverage and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->